### PR TITLE
chore(release): publish-crate skip ci

### DIFF
--- a/crates/plugin_import/Cargo.toml
+++ b/crates/plugin_import/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "swc_plugin_import"
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 handlebars = "4.3.3"


### PR DESCRIPTION
publish crate because upgrading SWC version