### PR TITLE
fix: extensions.styledComponents typo

### DIFF
--- a/.changeset/smart-jokes-exist.md
+++ b/.changeset/smart-jokes-exist.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/swc-plugins": patch
+---
+
+fix: extensions.styledComponents typo

--- a/binding.js
+++ b/binding.js
@@ -111,11 +111,11 @@ function boolToObj(input) {
 }
 
 function optionsToString(options) {
-  const styledComponent = boolToObj(options.styledComponent);
+  const styledComponents = boolToObj(options.styledComponents);
   const emotion = boolToObj(options.emotion);
 
-  if (styledComponent && typeof styledComponent !== "string") {
-    options.styledComponent = JSON.stringify(styledComponent);
+  if (styledComponents && typeof styledComponents !== "string") {
+    options.styledComponents = JSON.stringify(styledComponents);
   }
 
   if (emotion && typeof emotion !== "string") {

--- a/readme.md
+++ b/readme.md
@@ -333,7 +333,7 @@ will become something like this:
 import { foo } from '/project/node_modules/your-lib/node_modules/@swc/helpers';
 ```
 
-#### extensions.styledComponent
+#### extensions.styledComponents
 
 - Type:
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 /**
- * The type description of Extensions.emotion and Extensions.styledComponent are
+ * The type description of Extensions.emotion and Extensions.styledComponents are
  * copied from https://nextjs.org/docs/advanced-features/compiler#emotion
  */
 import { JsMinifyOptions, Options } from "./swcTypes";
@@ -82,7 +82,7 @@ export interface Extensions {
   };
   modernjsSsrLoaderId?: boolean;
   loadableComponents?: boolean;
-  styledComponent?:
+  styledComponents?:
     | boolean
     | {
         displayName?: boolean;


### PR DESCRIPTION
Fix `extensions.styledComponents` typo.