### PR TITLE
fix: incorrect lodash.ids type

### DIFF
--- a/.changeset/young-lamps-bake.md
+++ b/.changeset/young-lamps-bake.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/swc-plugins": patch
+---
+
+fix: incorrect lodash.ids type

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -78,7 +78,7 @@ export interface Extensions {
   };
   lodash?: {
     cwd?: string;
-    ids?: string;
+    ids?: string[];
   };
   modernjsSsrLoaderId?: boolean;
   loadableComponents?: boolean;


### PR DESCRIPTION
Fix incorrect lodash.ids type.

![image](https://github.com/web-infra-dev/swc-plugins/assets/7237365/a79d43df-f6d6-4330-9d35-bfef75953fc4)
