### PR TITLE
fix(plugin_lodash): invalid local name

### DIFF
--- a/.changeset/lovely-students-taste.md
+++ b/.changeset/lovely-students-taste.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/swc-plugins": patch
+---
+
+fix(plugin-lodash): invalid local name

--- a/crates/plugin_lodash/src/lib.rs
+++ b/crates/plugin_lodash/src/lib.rs
@@ -254,7 +254,7 @@ impl VisitMut for PluginLodash {
           // Check if this import should be replaced
           if self.pkg_map.get(source).is_some() {
             // Convert _.map() -> map#0()
-            let local_name = format!("{}#{}", &prop.sym, self.imported_names.len());
+            let local_name = format!("_{}{}", &prop.sym, self.imported_names.len());
             let local = Ident::new(
               JsWord::from(local_name),
               Span::dummy_with_cmt().apply_mark(self.top_level_mark),

--- a/crates/plugin_lodash/tests/fixtures/mixed-fixtures/lodash-esmodule/actual.js
+++ b/crates/plugin_lodash/tests/fixtures/mixed-fixtures/lodash-esmodule/actual.js
@@ -1,0 +1,8 @@
+import _, { add } from 'lodash';
+import _es, { add as addEs } from 'lodash-es';
+
+add(1, 2);
+_.map([1], () => {});
+
+addEs(1, 2);
+_es.map([1], () => {});

--- a/crates/plugin_lodash/tests/fixtures/mixed-fixtures/lodash-esmodule/expected.js
+++ b/crates/plugin_lodash/tests/fixtures/mixed-fixtures/lodash-esmodule/expected.js
@@ -1,0 +1,12 @@
+import _map3 from "lodash-es/map";
+import _map2 from "lodash/map";
+import addEs from "lodash-es/add";
+import add from "lodash/add";
+add(1, 2);
+_map2([
+1
+], function() {});
+addEs(1, 2);
+_map3([
+1
+], function() {});

--- a/crates/plugin_lodash/tests/fixtures/mixed-fixtures/lodash-esmodule/option.json
+++ b/crates/plugin_lodash/tests/fixtures/mixed-fixtures/lodash-esmodule/option.json
@@ -1,0 +1,12 @@
+{
+  "swc": {},
+  "extensions": {
+    "lodash": {
+      "cwd": "",
+      "ids": ["lodash", "lodash-es"]
+    }
+  },
+  "module": {
+    "type": "esmodule"
+  }
+}


### PR DESCRIPTION
Fix invalid local name generated by `plugin_lodash`:

<img width="538" alt="Screen Shot 2023-06-01 at 11 59 36" src="https://github.com/web-infra-dev/swc-plugins/assets/7237365/05bf1209-d1c8-4881-a0ba-841d0e671d9f">
