### PR TITLE
chore(plugin_lodash): add lodash namespace to variables

### DIFF
--- a/crates/plugin_lodash/src/lib.rs
+++ b/crates/plugin_lodash/src/lib.rs
@@ -254,7 +254,7 @@ impl VisitMut for PluginLodash {
           // Check if this import should be replaced
           if self.pkg_map.get(source).is_some() {
             // Convert _.map() -> map#0()
-            let local_name = format!("_{}{}", &prop.sym, self.imported_names.len());
+            let local_name = format!("_lodash_{}{}", &prop.sym, self.imported_names.len());
             let local = Ident::new(
               JsWord::from(local_name),
               Span::dummy_with_cmt().apply_mark(self.top_level_mark),

--- a/crates/plugin_lodash/tests/fixtures/mixed-fixtures/lodash-esmodule/expected.js
+++ b/crates/plugin_lodash/tests/fixtures/mixed-fixtures/lodash-esmodule/expected.js
@@ -1,12 +1,12 @@
-import _map3 from "lodash-es/map";
-import _map2 from "lodash/map";
+import _lodash_map3 from "lodash-es/map";
+import _lodash_map2 from "lodash/map";
 import addEs from "lodash-es/add";
 import add from "lodash/add";
 add(1, 2);
-_map2([
+_lodash_map2([
 1
 ], function() {});
 addEs(1, 2);
-_map3([
+_lodash_map3([
 1
 ], function() {});


### PR DESCRIPTION
Reduce the chance of variable name conflicts