### PR TITLE
refactor: remove auto detect esmodule

### DIFF
--- a/.changeset/bright-snakes-fly.md
+++ b/.changeset/bright-snakes-fly.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/swc-plugins": minor
+---
+
+refactor: remove auto detect esmodule

--- a/crates/plugin_lock_corejs_version/tests/fixtures/lock-corejs/cjs/expected.js
+++ b/crates/plugin_lock_corejs_version/tests/fixtures/lock-corejs/cjs/expected.js
@@ -1,4 +1,3 @@
-"use strict";
 var _object_spread = require("@@swc/_/_object_spread");
 require("@@corejs/modules/es.object.to-string.js");
 require("@@corejs/modules/es.promise.js");

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/bugfix-169/expected-remove.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/bugfix-169/expected-remove.js
@@ -1,4 +1,3 @@
-"use strict";
 class Test extends React.Component {
   
 }

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-assign-property/expected-remove.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-assign-property/expected-remove.js
@@ -1,4 +1,3 @@
-"use strict";
 class Foo1 extends React.Component {
   render() {}
 

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-assign-property/expected-wrap.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-assign-property/expected-wrap.js
@@ -1,4 +1,3 @@
-"use strict";
 class Foo1 extends React.Component {
     render() {}
 }

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-extend-component/expected-remove.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-extend-component/expected-remove.js
@@ -1,4 +1,3 @@
-"use strict";
 class Foo1 extends Component {
   render() {}
 

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-extend-component/expected-wrap.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-extend-component/expected-wrap.js
@@ -1,9 +1,8 @@
-"use strict";
-const _define_property = require("@swc/helpers/_/_define_property");
+import { _ as _define_property } from "@swc/helpers/_/_define_property";
 class Foo1 extends Component {
     render() {}
 }
-_define_property._(Foo1, "propTypes", process.env.NODE_ENV !== "production" ? {
+_define_property(Foo1, "propTypes", process.env.NODE_ENV !== "production" ? {
     foo1: PropTypes.string
 } : {});
 class Foo2 extends Component {

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-extend-global-base-component/expected-remove.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/es-class-extend-global-base-component/expected-remove.js
@@ -1,11 +1,10 @@
-"use strict";
-const _define_property = require("@swc/helpers/_/_define_property");
+import { _ as _define_property } from "@swc/helpers/_/_define_property";
 class Foo1 extends GlobalComponent {
   render() {}
 
 }
 
-_define_property._(Foo1, "propTypes", {
+_define_property(Foo1, "propTypes", {
   foo1: PropTypes.string
 });
 

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/not-react-assign-property/expected-remove.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/not-react-assign-property/expected-remove.js
@@ -1,4 +1,3 @@
-"use strict";
 var foo = {};
 foo.propTypes = {
   foo: PropTypes.string

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/not-react-assign-property/expected-wrap.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/not-react-assign-property/expected-wrap.js
@@ -1,4 +1,3 @@
-"use strict";
 var foo = {};
 foo.propTypes = {
     foo: PropTypes.string

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/not-react/expected-remove.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/not-react/expected-remove.js
@@ -1,4 +1,3 @@
-"use strict";
 var foo = {
   propTypes: {
     foo: 'bar'

--- a/crates/plugin_react_utils/tests/fixtures/remove_prop_types/unsafe-wrap/expected-unsafe-wrap.js
+++ b/crates/plugin_react_utils/tests/fixtures/remove_prop_types/unsafe-wrap/expected-unsafe-wrap.js
@@ -1,4 +1,3 @@
-"use strict";
 class Foo1 extends React.Component {
     render() {}
 }

--- a/crates/plugin_react_utils/tests/main.rs
+++ b/crates/plugin_react_utils/tests/main.rs
@@ -33,7 +33,8 @@ fn main() {
       };
 
       let swc: Options = serde_json::from_str(r#"{
-        "jsc": { "target": "es2020", "externalHelpers": true, "parser": { "syntax": "ecmascript", "jsx": true } }
+        "jsc": { "target": "es2020", "externalHelpers": true, "parser": { "syntax": "ecmascript", "jsx": true } },
+        "isModule": true
       }"#).unwrap();
       let react_utils = ReactUtilsConfig {
         remove_prop_types: Some(remove_prop_types.clone()),
@@ -64,7 +65,7 @@ fn main() {
 
         let expected_code = read(expected_remove_path);
         tests.push(ExpectedInfo::new(
-          expected_path.to_string_lossy().to_string(),
+          expected_remove_path.to_string_lossy().to_string(),
           expected_code,
           Some(TransformConfig {
             swc: swc.clone(),

--- a/crates/plugin_ssr_loader_id/src/lib.rs
+++ b/crates/plugin_ssr_loader_id/src/lib.rs
@@ -342,7 +342,6 @@ mod test {
             filename: "/root/a.js".into(),
             cwd: PathBuf::from("/root"),
             config_hash: None,
-            is_source_esm: true,
           }),
         )
       },

--- a/crates/swc_plugins_collection/src/pass.rs
+++ b/crates/swc_plugins_collection/src/pass.rs
@@ -3,10 +3,9 @@ use std::{path::Path, sync::Arc};
 use modularize_imports::{modularize_imports, Config as ModularizedConfig};
 use plugin_config_routes::plugin_config_routes;
 use plugin_lock_corejs_version::lock_corejs_version;
-use plugin_remove_es_module_mark::remove_es_module_mark;
 use plugin_ssr_loader_id::plugin_ssr_loader_id;
 use swc_core::{
-  base::config::{ModuleConfig, Options},
+  base::config::Options,
   common::{chain, comments::Comments, pass::Either, FileName},
   ecma::visit::Fold,
   ecma::{transforms::base::pass::noop, visit::as_folder},
@@ -110,7 +109,7 @@ pub fn internal_transform_before_pass<'a>(
 
 pub fn internal_transform_after_pass<'a>(
   extensions: &Extensions,
-  swc_config: &Options,
+  _swc_config: &Options,
   plugin_context: Arc<PluginContext>,
 ) -> impl Fold + 'a {
   let lock_core_js = if let Some(config) = &extensions.lock_corejs_version {
@@ -128,13 +127,7 @@ pub fn internal_transform_after_pass<'a>(
     Either::Right(noop())
   };
 
-  let remove_es_module_mark = if let Some(ModuleConfig::CommonJs(_)) = swc_config.config.module && !plugin_context.is_source_esm {
-    Either::Left(remove_es_module_mark())
-  } else {
-    Either::Right(noop())
-  };
-
-  chain!(lock_core_js, remove_es_module_mark, loadable_components)
+  chain!(lock_core_js, loadable_components)
 }
 
 fn plugin_loadable_components<C: Comments>(comments: C) -> impl Fold {

--- a/crates/swc_plugins_collection/tests/snapshots/main__plugin-import.snap
+++ b/crates/swc_plugins_collection/tests/snapshots/main__plugin-import.snap
@@ -2,7 +2,6 @@
 source: crates/swc_plugins_collection/tests/main.rs
 expression: res.code
 ---
-"use strict";
 var _object_spread = require("@swc/helpers/_/_object_spread");
 var a = {};
 var b = _object_spread._({}, a);

--- a/crates/swc_plugins_utils/src/lib.rs
+++ b/crates/swc_plugins_utils/src/lib.rs
@@ -642,10 +642,6 @@ pub struct PluginContext {
   pub cwd: PathBuf,
 
   pub config_hash: Option<String>, // This can be used by plugins to do caching
-
-  // Use this to determine if we should remove __esModule mark in pure commonjs module
-  // Remove this when SWC fix https://github.com/swc-project/swc/issues/6500
-  pub is_source_esm: bool,
 }
 
 impl std::fmt::Debug for PluginContext {
@@ -658,7 +654,6 @@ impl std::fmt::Debug for PluginContext {
       .field("filename", &self.filename)
       .field("cwd", &self.cwd)
       .field("config_hash", &self.config_hash)
-      .field("is_source_esm", &self.is_source_esm)
       .finish()
   }
 }


### PR DESCRIPTION
In the early days, SWC has an issue that is it injected `__esModule` unexpectedly, see [here](https://github.com/swc-project/swc/issues/6500), so at that time, I use `is_esm` to check if the input code is esModule or not, if it isn't, then `__esModule` should not present in the exports, and I can remove it in the output code.

However this detection is not robust enough, it did not take `import.meta` and `top-level-await` into account, thank @咲奈Sakina for mentioning this.

Now, SWC fixed this issue, and we no longer need this behavior.