### PR TITLE
fix: remove pnpm engine limit

### DIFF
--- a/.changeset/wild-cougars-walk.md
+++ b/.changeset/wild-cougars-walk.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/swc-plugins": patch
+---
+
+fix: remove pnpm engine limitation

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "@swc/helpers": "0.5.1"
   },
   "engines": {
-    "node": ">=14.17.6",
-    "pnpm": ">=8.0.0 <=8.6.1"
+    "node": ">=14.17.6"
   },
   "packageManager": "pnpm@8.6.1",
   "scripts": {


### PR DESCRIPTION
The engine limit will break our users if they set `engine-strict` to `true`.

https://docs.npmjs.com/cli/v9/using-npm/config#engine-strict