### PR TITLE
fix: adapte syntax based on filename, do not transform core-js-pure

### DIFF
--- a/.changeset/neat-needles-jam.md
+++ b/.changeset/neat-needles-jam.md
@@ -1,0 +1,5 @@
+---
+"@modern-js/swc-plugins": patch
+---
+
+fix: adapte syntax based on filename, do not transform core-js-pure

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
   "cSpell.words": [
     "androideabi",
+    "cjsx",
     "eabi",
     "elems",
+    "mjsx",
     "modernjs",
     "rustc_hash",
     "Stylesheet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,6 +4186,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "insta",
+ "regex",
  "serde",
  "serde_json",
  "swc_core",

--- a/crates/plugin_lock_corejs_version/src/lib.rs
+++ b/crates/plugin_lock_corejs_version/src/lib.rs
@@ -9,7 +9,9 @@ use swc_core::{
 };
 
 static COREJS: &str = "core-js";
+static COREJS_START: &str = "core-js/";
 static SWC_HELPERS: &str = "@swc/helpers";
+static SWC_HELPERS_START: &str = "@swc/helpers/";
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -20,9 +22,9 @@ pub struct LockCoreJsVersion {
 
 impl LockCoreJsVersion {
   fn need_replace(&self, value: impl AsRef<str>) -> Option<String> {
-    if value.as_ref().starts_with(COREJS) {
+    if value.as_ref().starts_with(COREJS_START) {
       Some(value.as_ref().replace(COREJS, &self.corejs))
-    } else if value.as_ref().starts_with(SWC_HELPERS) {
+    } else if value.as_ref().starts_with(SWC_HELPERS_START) {
       Some(value.as_ref().replace(SWC_HELPERS, &self.swc_helpers))
     } else {
       None

--- a/crates/swc_plugins_core/Cargo.toml
+++ b/crates/swc_plugins_core/Cargo.toml
@@ -27,6 +27,7 @@ swc_core = { workspace = true, features = [
 swc_plugins_utils = { path = "../swc_plugins_utils" }
 serde_json = { workspace = true }
 serde = { workspace = true }
+regex = "1.6.0"
 
 [dev-dependencies]
 insta = "1.18.2"


### PR DESCRIPTION
## fix: lockCorejsVersion

lockCorejsVersion can transform 'core-js/path/to' to 'foo/bar/core-js/path/to'

Before lockCorejsVersion detect if import path is starts with 'core-js', now it detect if it starts with 'core-js/', to avoid detect 'core-js-pure'.

## fix: use js syntax to transform js module

As modern-js binding only passed config once, so during loader transform, js files are transformed using the same config, and the syntax is `TS` syntax, at most cases this is fine, but if using `TS` syntax, SWC cannot transform new decorator proposal correctly, so I did a hack here, to check if file name ends with JS like, Rust side will change the syntax accordingly