### PR TITLE
Chore/bump deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,11 @@
   "peerDependencies": {
     "@swc/helpers": ">=0.5.3"
   },
+  "peerDependenciesMeta": {
+    "@swc/helpers": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": ">=14.17.6"
   },


### PR DESCRIPTION
make @swc/helpers an optional peer dependency