### PR TITLE
ci: fix release workflow on darwin-x64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -396,3 +396,18 @@ jobs:
 
       - name: Prepare WASM plugins
         run: pnpm run build:wasm
+
+      - name: Release
+        uses: web-infra-dev/actions@v2
+        with:
+          # this expects you to have a script called release which does a build for your packages and calls changeset publish
+          version: latest
+          type: "release"
+          branch: ${{ github.ref_name }}
+          tools: "changeset"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          REF: ${{ github.ref }}
+          ONLY_RELEASE_TAG: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           - host: macos-latest
             target: x86_64-apple-darwin
             build: |
-              pnpm run build
+              pnpm run build --target x86_64-apple-darwin
               strip -x *.node
           - host: windows-latest
             build: pnpm run build
@@ -396,18 +396,3 @@ jobs:
 
       - name: Prepare WASM plugins
         run: pnpm run build:wasm
-
-      - name: Release
-        uses: web-infra-dev/actions@v2
-        with:
-          # this expects you to have a script called release which does a build for your packages and calls changeset publish
-          version: latest
-          type: "release"
-          branch: ${{ github.ref_name }}
-          tools: "changeset"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          REF: ${{ github.ref }}
-          ONLY_RELEASE_TAG: true


### PR DESCRIPTION
It should work now. The `.node` occurs on darwin-x64.

https://github.com/web-infra-dev/swc-plugins/actions/runs/10175895810/job/28145215389#step:7:30

<img width="331" alt="Google Chrome 2024-07-31 16 01 55" src="https://github.com/user-attachments/assets/eee68a5a-65f7-4e40-be48-6a21cf46c96f">


Previously, I saw `.node` missing in https://github.com/web-infra-dev/swc-plugins/actions/runs/9970281610/job/27550404062. (log seems outdated just right now, I only have a screenshot)

<img width="563" alt="Google Chrome 2024-07-31 15 03 33" src="https://github.com/user-attachments/assets/e3b0624e-053b-4a2d-bc41-f1cfd55ad76e">

